### PR TITLE
Fix space character in raise action.

### DIFF
--- a/dist/facade/poker.d.ts
+++ b/dist/facade/poker.d.ts
@@ -53,7 +53,7 @@ export default class Poker {
         chipRange?: ChipRange;
     };
     holeCards(): (Card[] | null)[];
-    actionTaken(action: 'fold' | 'check' | 'call' | 'bet' | ' raise', betSize?: number): void;
+    actionTaken(action: 'fold' | 'check' | 'call' | 'bet' | 'raise', betSize?: number): void;
     endBettingRound(): void;
     showdown(): void;
     winners(): [SeatIndex, {

--- a/src/facade/poker.ts
+++ b/src/facade/poker.ts
@@ -164,7 +164,7 @@ export default class Poker {
         })
     }
 
-    actionTaken(action: 'fold' | 'check' | 'call' | 'bet' | ' raise', betSize?: number) {
+    actionTaken(action: 'fold' | 'check' | 'call' | 'bet' | 'raise', betSize?: number) {
         this._table.actionTaken(ActionFlag[action.toUpperCase()], betSize)
     }
 


### PR DESCRIPTION
The 'raise' action has an extra space character, causing incorrect suggestions in the editor and parameter mismatches in the actionTaken function. I have removed the extra space character from the raise action definition. This update ensures accurate code suggestions and correct function parameter handling, improving the overall functionality and reliability of the library.